### PR TITLE
Small fix for buggy devices

### DIFF
--- a/wiremaps/collector/helpers/lldp.py
+++ b/wiremaps/collector/helpers/lldp.py
@@ -226,4 +226,5 @@ class LldpSpeedCollector(SpeedCollector):
         """Callback handling autoneg"""
         for oid in results:
             port = int(oid.split(".")[-1])
-            self.equipment.ports[port].autoneg = bool(results[oid] == 1)
+            if port in self.equipment.ports:
+                self.equipment.ports[port].autoneg = bool(results[oid] == 1)


### PR DESCRIPTION
Hi,

I've experienced an issue with wiremaps because I have a device that reported an additional port entry at .1.0.8802.1.1.2.1.5.4623.1.2.1.1.2 (see traces below). I've done a very simple modification to fix that.
HTH,
Simon

Output of LLDP-MIB:
iso.0.8802.1.1.2.1.3.7.1.3.1 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.2 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.3 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.4 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.5 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.6 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.7 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.8 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.9 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.10 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.11 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.12 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.13 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.14 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.15 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.16 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.17 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.18 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.19 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.20 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.21 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.22 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.23 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.24 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.25 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.26 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.27 = Hex-STRING: 08 00 38 38 8E 9A 
iso.0.8802.1.1.2.1.3.7.1.3.28 = Hex-STRING: 08 00 38 38 8E 9A 

Output of LLDP-EXT-DOT3-MIB:lldpXdot3LocPortAutoNegEnabled
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.1 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.2 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.3 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.4 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.5 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.6 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.7 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.8 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.9 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.10 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.11 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.12 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.13 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.14 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.15 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.16 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.17 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.18 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.19 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.20 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.21 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.22 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.23 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.24 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.25 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.26 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.27 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.28 = INTEGER: 1
.1.0.8802.1.1.2.1.5.4623.1.2.1.1.2.201 = INTEGER: 2 <----- err...
