### PR TITLE
fix: IP ranges in iplist without community are ignored

### DIFF
--- a/wiremaps/collector/core.py
+++ b/wiremaps/collector/core.py
@@ -46,7 +46,7 @@ class CollectorService(service.Service):
             community = None
             if len(parts) > 1:
                 community = parts[1]
-                self.ips += [(ip, community)]
+            self.ips += [(ip, community)]
         ipfile.close()
 
     def startExploration(self):


### PR DESCRIPTION
If one does not have the optional community string for an IP range in the
iplist file that IP range will get ignored. By moving the self.ips assignment out of the if statement we make sure that an IP gets added to ips rather or not it has a community string with it.
